### PR TITLE
Change documentation to improve performance for scripts

### DIFF
--- a/R/add_shortcuts.R
+++ b/R/add_shortcuts.R
@@ -29,7 +29,7 @@
 #' # Add shortcuts to ~/.shrtcts.yaml (see help above)
 #'
 #' # Add this to your ~/.Rprofile to automatically load shortcuts
-#' if (interactive() & requireNamespace("shrtcts", quietly = TRUE)) {
+#' if (interactive() && requireNamespace("shrtcts", quietly = TRUE)) {
 #'   shrtcts::add_rstudio_shortcuts()
 #' }
 #'

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ run `add_rstudio_shortcuts()` whenever you update your shortcuts.)
 
 ``` r
 # ~/.Rprofile
-if (interactive() & requireNamespace("shrtcts", quietly = TRUE)) {
+if (interactive() && requireNamespace("shrtcts", quietly = TRUE)) {
   shrtcts::add_rstudio_shortcuts()
 }
 ```
@@ -51,7 +51,7 @@ shortcuts assignments.
 
 ``` r
 # ~/.Rprofile
-if (interactive() & requireNamespace("shrtcts", quietly = TRUE)) {
+if (interactive() && requireNamespace("shrtcts", quietly = TRUE)) {
   shrtcts::add_rstudio_shortcuts(set_keyboard_shortcuts = TRUE)
 }
 ```

--- a/man/add_rstudio_shortcuts.Rd
+++ b/man/add_rstudio_shortcuts.Rd
@@ -210,7 +210,7 @@ shortcut is a YAML list item with the following structure:\if{html}{\out{<div cl
 # Add shortcuts to ~/.shrtcts.yaml (see help above)
 
 # Add this to your ~/.Rprofile to automatically load shortcuts
-if (interactive() & requireNamespace("shrtcts", quietly = TRUE)) {
+if (interactive() && requireNamespace("shrtcts", quietly = TRUE)) {
   shrtcts::add_rstudio_shortcuts()
 }
 

--- a/man/fragments/shrtcts-quick-start.Rmd
+++ b/man/fragments/shrtcts-quick-start.Rmd
@@ -31,7 +31,7 @@ and run `add_rstudio_shortcuts()` whenever you update your shortcuts.)
 
 ```{r eval=FALSE}
 # ~/.Rprofile
-if (interactive() & requireNamespace("shrtcts", quietly = TRUE)) {
+if (interactive() && requireNamespace("shrtcts", quietly = TRUE)) {
   shrtcts::add_rstudio_shortcuts()
 }
 ```
@@ -40,7 +40,7 @@ You can also tell **shrtcts** to automatically update the keyboard shortcuts ass
 
 ```{r eval=FALSE}
 # ~/.Rprofile
-if (interactive() & requireNamespace("shrtcts", quietly = TRUE)) {
+if (interactive() && requireNamespace("shrtcts", quietly = TRUE)) {
   shrtcts::add_rstudio_shortcuts(set_keyboard_shortcuts = TRUE)
 }
 ```


### PR DESCRIPTION
The instructions for loading the package in `.Rprofile` are currently given as

> ```r
> if (interactive() & requireNamespace("shrtcts", quietly = TRUE)) {
>   shrtcts::add_rstudio_shortcuts()
> }
> ```

This has the effect of *always* executing `requireNamespace`, even when not in interactive mode. By using short-circuited `&&` instead of `&`, this PR improves the performance of running non-interactive scripts by never attempting to load the package.